### PR TITLE
Change YouTube link to latest live streams

### DIFF
--- a/src/apireview.net/Pages/About.razor
+++ b/src/apireview.net/Pages/About.razor
@@ -13,7 +13,7 @@
         </div>
         <div class="card-footer">
             <a href="/backlog" class="btn btn-success">View Backlog</a>
-            <a href="https://www.youtube.com/@NETFoundation/videos?view=2&sort=dd&live_view=503&shelf_id=3" class="btn btn-secondary">
+            <a href="https://www.youtube.com/@NETFoundation/streams" class="btn btn-secondary">
                 <span class="oi oi-monitor" aria-hidden="true"></span> Watch
             </a>
         </div>

--- a/src/apireview.net/Pages/About.razor
+++ b/src/apireview.net/Pages/About.razor
@@ -13,7 +13,7 @@
         </div>
         <div class="card-footer">
             <a href="/backlog" class="btn btn-success">View Backlog</a>
-            <a href="https://www.youtube.com/playlist?list=PL1rZQsJPBU2S49OQPjupSJF-qeIEz9_ju" class="btn btn-secondary">
+            <a href="https://www.youtube.com/@NETFoundation/videos?view=2&sort=dd&live_view=503&shelf_id=3" class="btn btn-secondary">
                 <span class="oi oi-monitor" aria-hidden="true"></span> Watch
             </a>
         </div>


### PR DESCRIPTION
The playlist link has been defunct for a while, as the live streams don't get added into the playlist.

This updated link goes to the latest live streams, including ".NET API Review" streams as well as others, but this is a reasonable and better experience.