### PR TITLE
Force time localization with in-app navigation

### DIFF
--- a/src/apireview.net/App.razor
+++ b/src/apireview.net/App.razor
@@ -44,5 +44,6 @@
     <script src="_framework/blazor.web.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="js/bootstrap.bundle.min.js"></script>
+    <script src="js/localizeTime.js"></script>
 </body>
 </html>

--- a/src/apireview.net/Pages/Schedule.razor
+++ b/src/apireview.net/Pages/Schedule.razor
@@ -52,38 +52,3 @@
     Videos are streamed to the <a href="https://www.youtube.com/@@NETFoundation/streams">.NET Foundation YouTube channel</a>.
     This calendar is available <a href="@CalendarService.Url">as an .ics file</a> you can add to your favorite calendar app.
 </p>
-
-<script>
-    (function () {
-        // Update <time> elements to user's local time,
-        // but if the date would differ keep Pacific time and show PST/PDT
-        document.querySelectorAll('time[datetime]').forEach(function (el) {
-            var isoStr = el.getAttribute('datetime');
-            var dt = new Date(isoStr);
-            var cell = el.closest('[data-date]');
-            var cellDate = cell ? cell.getAttribute('data-date') : null;
-            var localDate = dt.getFullYear() + '-' +
-                String(dt.getMonth() + 1).padStart(2, '0') + '-' +
-                String(dt.getDate()).padStart(2, '0');
-            if (cellDate && localDate !== cellDate) {
-                // Date would change — keep Pacific time; label it PST or PDT from the offset
-                var offsetMatch = isoStr.match(/([+-]\d{2}):\d{2}$/);
-                var tzLabel = (offsetMatch && offsetMatch[1] === '-07') ? 'PDT' : 'PST';
-                el.textContent = el.textContent + '\u00a0' + tzLabel;
-            } else {
-                el.textContent = dt.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-            }
-        });
-
-        // Re-highlight today/past cells using the user's local date
-        var now = new Date();
-        var todayStr = now.getFullYear() + '-' +
-            String(now.getMonth() + 1).padStart(2, '0') + '-' +
-            String(now.getDate()).padStart(2, '0');
-        document.querySelectorAll('[data-date]').forEach(function (el) {
-            var d = el.getAttribute('data-date');
-            el.classList.toggle('today', d === todayStr);
-            el.classList.toggle('past', d < todayStr);
-        });
-    })();
-</script>

--- a/src/apireview.net/wwwroot/js/localizeTime.js
+++ b/src/apireview.net/wwwroot/js/localizeTime.js
@@ -1,0 +1,50 @@
+﻿function localizeTime() {
+    // Update <time> elements to user's local time,
+    // but if the date would differ keep Pacific time and show PST/PDT
+    document.querySelectorAll('time[datetime]').forEach(function (el) {
+        var isoStr = el.getAttribute('datetime');
+        var dt = new Date(isoStr);
+        var cell = el.closest('[data-date]');
+        var cellDate = cell ? cell.getAttribute('data-date') : null;
+        var localDate = dt.getFullYear() + '-' +
+            String(dt.getMonth() + 1).padStart(2, '0') + '-' +
+            String(dt.getDate()).padStart(2, '0');
+        if (cellDate && localDate !== cellDate) {
+            // Date would change — keep Pacific time; label it PST or PDT from the offset
+            var offsetMatch = isoStr.match(/([+-]\d{2}):\d{2}$/);
+            var tzLabel = (offsetMatch && offsetMatch[1] === '-07') ? 'PDT' : 'PST';
+            el.textContent = el.textContent + '\u00a0' + tzLabel;
+        } else {
+            el.textContent = dt.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+        }
+    });
+
+    // Re-highlight today/past cells using the user's local date
+    var now = new Date();
+    var todayStr = now.getFullYear() + '-' +
+        String(now.getMonth() + 1).padStart(2, '0') + '-' +
+        String(now.getDate()).padStart(2, '0');
+    document.querySelectorAll('[data-date]').forEach(function (el) {
+        var d = el.getAttribute('data-date');
+        el.classList.toggle('today', d === todayStr);
+        el.classList.toggle('past', d < todayStr);
+    });
+}
+
+const observeUrlChange = () => {
+    if (document.location.href.includes("/schedule")) {
+        localizeTime();
+    }
+    let oldHref = document.location.href;
+    const body = document.querySelector("body");
+    const observer = new MutationObserver(mutations => {
+        if (oldHref !== document.location.href) {
+            oldHref = document.location.href;
+            if (document.location.href.includes("/schedule")) {
+                localizeTime();
+            }
+        }
+    });
+    observer.observe(body, { childList: true, subtree: true });
+};
+window.onload = observeUrlChange;


### PR DESCRIPTION
Schedule does not run the script for the local timezone calculation when navigating within the blazor app (I live in Europe):
See the behavior before (it shows 10:00 and 11:00 instead of 19:00 when doing in-app navigation - but if I open the schedule page directly, it shows the correct time)

BEFORE:

https://github.com/user-attachments/assets/0a6bd816-eaef-438c-95b7-e11b9e7a341d


AFTER:

https://github.com/user-attachments/assets/b9bfa175-fdf2-4f36-99f5-d4e21798b629




This is not perfect though, if I navigate with the buttons here:
<img width="142" height="69" alt="image" src="https://github.com/user-attachments/assets/3cdd8444-f4eb-4583-8a78-de3fd7137e32" />

the time is sometimes localized, sometimes not. This annoys me, but
- I never use those buttons
- AI had no good idea either, and I spent shamefully too much time to try to figure this out.

Maybe @halter73 knows how to do this in a clean way? - I am open to refactor this PR.