### PR TITLE
Add API Catalog link

### DIFF
--- a/src/apireview.net/Shared/MainLayout.razor
+++ b/src/apireview.net/Shared/MainLayout.razor
@@ -37,6 +37,11 @@
                 </NavLink>
             </li>
             <li class="nav-item">
+                <NavLink class="nav-link" href="https://catalog.apireview.net/">
+                    <span class="oi oi-external-link" aria-hidden="true"></span> API Catalog
+                </NavLink>
+            </li>
+            <li class="nav-item">
                 <NavLink class="nav-link" href="https://github.com/bartonjs/apireview.net">
                     <span class="oi oi-code" aria-hidden="true"></span> Source
                 </NavLink>


### PR DESCRIPTION
I was looking for the API catalog and remembered it was on apireview.net now, but https://www.google.com/search?q=apireview.net+catalog didn't turn it up 😅

Would be useful to link from the main site.